### PR TITLE
Fix cache delete return type error

### DIFF
--- a/src/php/Adapters/WordPress/Cache.php
+++ b/src/php/Adapters/WordPress/Cache.php
@@ -49,7 +49,7 @@ class Cache implements ICache {
 	 * @return bool Success status.
 	 */
 	public function delete( string $key ): bool {
-		return delete_transient( $this->prefix . $key );
+		return (bool) delete_transient( $this->prefix . $key );
 	}
 
 	/**
@@ -67,7 +67,7 @@ class Cache implements ICache {
 		);
 
 		foreach ( $prefixed_keys as $key ) {
-			delete_transient( $key );
+			(bool) delete_transient( $key );
 		}
 
 		return true;


### PR DESCRIPTION
- WordPress's delete_transient() can return null in edge cases
- PHP 8.0+ strictly enforces return type declarations
- Cast return value to bool to ensure type safety across all PHP versions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `delete_transient` results are cast to `bool` in the WordPress `Cache` adapter for strict return types.
> 
> - **Backend**
>   - **WordPress Cache adapter** (`src/php/Adapters/WordPress/Cache.php`):
>     - Cast `delete_transient` result to `bool` in `delete()`.
>     - Cast `delete_transient` calls to `bool` within `clear_keys()` loop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ef10057754d6d5dd670ee39ed7cd49b94a9bd43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->